### PR TITLE
build: add --no-cache to build args

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,6 +19,7 @@ var (
 	branch   string
 	nodeType string
 	imageTag string
+	noCache  bool
 )
 
 var buildCmd = &cobra.Command{
@@ -46,6 +47,7 @@ func init() {
 	buildCmd.Flags().StringVar(&branch, "branch", "", "Branch name (required with --repo)")
 	buildCmd.Flags().StringVar(&nodeType, "node-type", "", fmt.Sprintf("Node type: %v (required)", supportedNodeTypes))
 	buildCmd.Flags().StringVar(&imageTag, "tag", "", "Custom tag for the Docker image (required)")
+	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "Build the image without using Docker cache")
 
 	buildCmd.MarkFlagRequired("tag")
 	buildCmd.MarkFlagRequired("node-type")
@@ -136,6 +138,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		Checkout: gitBranch,
 		Tag:      imageTag + ":aurora",
 		NodeType: nodeType,
+		NoCache:  noCache,
 	})
 	if err != nil {
 		return fmt.Errorf("build failed: %w", err)

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -38,6 +38,7 @@ type BuildOptions struct {
 	Checkout string // Branch, tag, or commit to checkout
 	Tag      string // Image tag
 	NodeType string // Node type (lnd, bitcoind, etc.)
+	NoCache  bool   // Build without Docker cache
 }
 
 // Build builds a Docker image with the given options.
@@ -68,8 +69,13 @@ func (b *Builder) Build(ctx context.Context, opts BuildOptions) error {
 		"--build-arg", fmt.Sprintf("checkout=%s", opts.Checkout),
 		"-t", opts.Tag,
 		"-f", dockerfilePath,
-		tmpDir,
 	}
+
+	if opts.NoCache {
+		args = append(args, "--no-cache")
+	}
+
+	args = append(args, tmpDir)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 


### PR DESCRIPTION
## Description

Add an optional `--no-cache` flag to the `aurora build` command, allowing users to build Docker images without using Docker's build cache. This is useful when you want to ensure a completely fresh build.

**Usage:**
```bash
aurora build --pr --node-type lnd --tag my-test --no-cache
```


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / code improvement
- [ ] 🐳 Dockerfile changes (new or updated node type)

## Related Issue

N/A

## How Has This Been Tested?

- [x] `make test` passes
- [x] `make fmt` produces no changes
- [ ] Manual testing with `aurora build`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (README, etc.) if needed
- [x] My changes generate no new warnings
- [x] Any new dependencies have been added to `go.mod`