### PR TITLE
docker: fix warning for lnd dockerfile

### DIFF
--- a/internal/docker/dockerfiles/lnd/Dockerfile
+++ b/internal/docker/dockerfiles/lnd/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.25.5-alpine AS builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
-ENV GODEBUG netdns=cgo
+ENV GODEBUG=netdns=cgo
 
 # Pass a tag, branch or a commit using build-arg.  This allows a docker
 # image to be built from a specified Git state.  The default image


### PR DESCRIPTION
## Description

Update ENV instruction in the LND Dockerfile to use the modern key=value format, replacing the legacy ENV key value syntax.

  Type of Change

  - 🐳 Dockerfile changes (new or updated node type)

  Related Issue

  Fixes #5

  How Has This Been Tested?

  - make fmt produces no changes
  - Manual testing with aurora build

  Checklist

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - My changes generate no new warnings