### PR TITLE
cmd: add list command to display aurora-built images

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/abdulkbk/aurora/internal/docker"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Docker images built by Aurora",
+	Long: `List all Docker images that were built by Aurora.
+	Aurora tags all built images with the ":aurora" suffix, so this command
+	filters local Docker images by that tag and displays them in a table.
+	Example:
+		aurora list`,
+	RunE: runList,
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	images, err := docker.ListAuroraImages()
+	if err != nil {
+		return err
+	}
+
+	if len(images) == 0 {
+		fmt.Println("No Aurora images found. Build one with: " +
+			"aurora build")
+
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "IMAGE\tTAG\tCREATED")
+
+	for _, img := range images {
+		fmt.Fprintf(
+			w, "%s\t%s\t%s\n", img.Repository, img.Tag,
+			img.CreatedSince,
+		)
+	}
+
+	return w.Flush()
+}

--- a/internal/docker/lister.go
+++ b/internal/docker/lister.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ImageInfo holds information about a Docker image built by Aurora.
+type ImageInfo struct {
+	Repository   string
+	Tag          string
+	CreatedSince string
+}
+
+// ListAuroraImages returns all Docker images tagged with the ":aurora" suffix.
+func ListAuroraImages() ([]ImageInfo, error) {
+	cmd := exec.Command(
+		"docker", "images",
+		"--filter", "reference=*:aurora",
+		"--format", "{{.Repository}}\t{{.Tag}}\t{{.CreatedSince}}",
+	)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to list Docker images: %w", err)
+	}
+
+	var images []ImageInfo
+	for line := range strings.SplitSeq(
+		strings.TrimSpace(out.String()), "\n") {
+
+		if line == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+
+		images = append(images, ImageInfo{
+			Repository:   parts[0],
+			Tag:          parts[1],
+			CreatedSince: parts[2],
+		})
+	}
+
+	return images, nil
+}


### PR DESCRIPTION
Closes #12

  Adds an `aurora list` command that queries the local Docker daemon for images built by Aurora and displays them in a readable table.

  ## Changes

  - `cmd/list.go` — new `list` subcommand registered with the root command
  - `internal/docker/lister.go` — `ListAuroraImages()` function that filters Docker images by the `:aurora` tag suffix using the same CLI approach as the existing builder

  ## Example output

  IMAGE              TAG      CREATED
  my-lnd-test        aurora   2 hours ago
  my-btcd-fork       aurora   1 day ago

  If no Aurora images are found, the command prints a helpful message directing the user to `aurora build`.