### PR TITLE
Replace emoji CLI output with ASCII prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,37 +22,37 @@ all: build
 
 ## build: Build the aurora binary
 build:
-	@echo "🔨 Building $(BINARY_NAME)..."
+	@echo ".. building $(BINARY_NAME)..."
 	$(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME) .
-	@echo "✅ Built $(BINARY_NAME)"
+	@echo "[ok] built $(BINARY_NAME)"
 
 ## install: Install aurora to GOPATH/bin
 install:
-	@echo "📦 Installing $(BINARY_NAME)..."
+	@echo ".. installing $(BINARY_NAME)..."
 	$(GOBUILD) $(LDFLAGS) -o $(GOPATH)/bin/$(BINARY_NAME) .
-	@echo "✅ Installed to $(GOPATH)/bin/$(BINARY_NAME)"
+	@echo "[ok] installed to $(GOPATH)/bin/$(BINARY_NAME)"
 
 ## test: Run all tests
 test:
-	@echo "🧪 Running tests..."
+	@echo ".. running tests..."
 	$(GOTEST) -v ./...
 
 ## fmt: Format Go code
 fmt:
-	@echo "🎨 Formatting code..."
+	@echo ".. formatting code..."
 	$(GOFMT) ./...
 
 ## tidy: Tidy and verify module dependencies
 tidy:
-	@echo "📦 Tidying modules..."
+	@echo ".. tidying modules..."
 	$(GOMOD) tidy
 	$(GOMOD) verify
 
 ## clean: Remove build artifacts
 clean:
-	@echo "🧹 Cleaning..."
+	@echo ".. cleaning..."
 	@rm -f $(BINARY_NAME)
-	@echo "✅ Cleaned"
+	@echo "[ok] cleaned"
 
 ## run: Build and run with sample args (for testing)
 run: build

--- a/README.md
+++ b/README.md
@@ -57,22 +57,22 @@ aurora build --repo https://github.com/username/lnd --branch feature-branch --ta
 ### Example Output
 
 ```
-🚀 Aurora Build
+ [aurora] build
 ===============
-📋 PR:     lightningnetwork/lnd#10545
-🔍 Fetching PR details from GitHub...
-📝 Title:  switchrpc: improve SendOnion error handling
-📊 State:  open
-🔗 Fork:   https://github.com/calvinrzachman/lnd.git
-🌿 Branch: switchrpc-error-handle-combined
-📦 Type:   lnd (default)
-🏷️  Tag:    sendonion
+>> PR:     lightningnetwork/lnd#10545
+.. fetching PR details
+>> Title:  switchrpc: improve SendOnion error handling
+>> State:  open
+>> Fork:   https://github.com/calvinrzachman/lnd.git
+>> Branch: switchrpc-error-handle-combined
+>> type:   lnd (default)
+>> tag:    sendonion
 
-🔨 Building Docker image...
+.. building image
 ----------------------------
 [... Docker build output ...]
 ----------------------------
-✅ Build complete! Image: sendonion:aurora
+[ok] build complete! Image: sendonion:aurora
 
 To use in Polar, add this as a custom node image.
 ```

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -83,7 +83,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid node type %q, must be one of: %v", nodeType, supportedNodeTypes)
 	}
 
-	fmt.Println("🚀 Aurora Build")
+	fmt.Println("[aurora] build")
 	fmt.Println("===============")
 
 	var gitURL, gitBranch, owner, repo string
@@ -97,8 +97,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 		owner, repo = prInfo.Owner, prInfo.Repo
 
-		fmt.Printf("📋 PR:     %s/%s#%d\n", prInfo.Owner, prInfo.Repo, prInfo.PRNumber)
-		fmt.Println("🔍 Fetching PR details from GitHub...")
+		fmt.Printf(">> PR:     %s/%s#%d\n", prInfo.Owner, prInfo.Repo, prInfo.PRNumber)
+		fmt.Println(".. fetching PR details")
 
 		client := github.NewClient()
 		prDetails, err := client.GetPRDetails(prInfo.Owner, prInfo.Repo, prInfo.PRNumber)
@@ -106,10 +106,10 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to fetch PR details: %w", err)
 		}
 
-		fmt.Printf("📝 Title:  %s\n", prDetails.Title)
-		fmt.Printf("📊 State:  %s\n", prDetails.State)
-		fmt.Printf("🔗 Fork:   %s\n", prDetails.ForkURL)
-		fmt.Printf("🌿 Branch: %s\n", prDetails.Branch)
+		fmt.Printf(">> Title:  %s\n", prDetails.Title)
+		fmt.Printf(">> State:  %s\n", prDetails.State)
+		fmt.Printf(">> Fork:   %s\n", prDetails.ForkURL)
+		fmt.Printf(">> Branch: %s\n", prDetails.Branch)
 
 		gitURL = prDetails.ForkURL
 		gitBranch = prDetails.Branch
@@ -124,8 +124,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		gitURL = repoInfo.CloneURL()
 		gitBranch = branch
 
-		fmt.Printf("🔗 Repo:   %s\n", gitURL)
-		fmt.Printf("🌿 Branch: %s\n", gitBranch)
+		fmt.Printf(">> Repo:   %s\n", gitURL)
+		fmt.Printf(">> Branch: %s\n", gitBranch)
 	}
 
 	// Auto-detect node type if not provided
@@ -140,9 +140,9 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		nodeType = detected
 	}
 
-	fmt.Printf("📦 Type:   %s\n", nodeType)
+	fmt.Printf(">> type:   %s\n", nodeType)
 
-	fmt.Printf("🏷️  Tag:    %s\n", imageTag)
+	fmt.Printf(">> tag:    %s\n", imageTag)
 	fmt.Println()
 
 	// Create Docker builder
@@ -152,7 +152,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build the image
-	fmt.Println("🔨 Building Docker image...")
+	fmt.Println(".. building image")
 	fmt.Println("----------------------------")
 
 	ctx := context.Background()
@@ -169,7 +169,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 	fmt.Println("----------------------------")
-	fmt.Printf("✅ Build complete! Image: %s\n", imageTag)
+	fmt.Printf("[ok] build complete! Image: %s\n", imageTag)
 	fmt.Println()
 	fmt.Println("To use in Polar, add this as a custom node image.")
 


### PR DESCRIPTION
Replaces emoji indicators in CLI output with professional ASCII prefixes to better match the cypherpunk/developer aesthetic of Bitcoin and Lightning Network tooling.

## Changes Made
- **cmd/build.go**: Replaced all emoji output with ASCII prefixes
- **README.md**: Updated example output section to match new format  
- **Makefile**: Updated build/test messages for consistency

## Testing
 Tested CLI output with `aurora build --pr` command
 All ASCII prefixes display correctly

Fixes #14